### PR TITLE
Fix compile errors in g++-5.4

### DIFF
--- a/src/libbruce/CMakeLists.txt
+++ b/src/libbruce/CMakeLists.txt
@@ -56,6 +56,10 @@ add_executable(testbruce
     test/testtypes.cpp
     )
 
+set_target_properties(testbruce PROPERTIES
+    CXX_STANDARD 11
+    )
+
 target_include_directories(testbruce
     PRIVATE src  # Testing private headers
     )

--- a/src/libbruce/src/tree_impl.cpp
+++ b/src/libbruce/src/tree_impl.cpp
@@ -6,6 +6,8 @@
 #include "overflow_node.h"
 #include "helpers.h"
 
+#include <set>
+
 namespace libbruce {
 
 tree_impl::tree_impl(be::be &be, maybe_nodeid rootID, mempool &mempool, const tree_functions &fns)


### PR DESCRIPTION
- #include <set>
- compile tests with c++11 (required by catch)